### PR TITLE
Add Short Page Support: Save Button Styles

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,12 +11,13 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "*://*.youtube.com/*",
-        "*://youtube.com/*",
-        "*://youtu.be/*"
-      ],
+      "matches": ["*://*.youtube.com/*", "*://youtube.com/*", "*://youtu.be/*"],
       "css": ["./styles/button.css"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["*://*.youtube.com/shorts/*", "*://youtube.com/shorts/*"],
+      "css": ["./styles/shorts.css"],
       "run_at": "document_start"
     }
   ],

--- a/styles/button.css
+++ b/styles/button.css
@@ -1,16 +1,18 @@
 /* Using maximum specificity to make sure styles are not overwritten */
 
 :root {
-    /* Magic Numbers */
-    --bsf-save-btn-left-side-width: 24.5px;
-    --bsf-save-btn-left-side-padding: 6.5px;
-    --bsf-save-btn-icon-translate-y: 3px;
-    --bsf-save-btn-sides-gap-width: 28px;
-    --bsf-save-btn-right-side-padding: 8.5px;
-    --bsf-save-btn-right-side-text-to-icon-gap: var(--bsf-save-btn-right-side-padding);
-    /* Yt action btn height is a static 35.9896px but achieved through other styles not the height param */
-    /* FIXME Github issue #1 (manifest -> homepage_url) */
-    --bsf-yt-action-btn-height: 35.99px;
+  /* Magic Numbers */
+  --bsf-save-btn-left-side-width: 24.5px;
+  --bsf-save-btn-left-side-padding: 6.5px;
+  --bsf-save-btn-icon-translate-y: 3px;
+  --bsf-save-btn-sides-gap-width: 28px;
+  --bsf-save-btn-right-side-padding: 8.5px;
+  --bsf-save-btn-right-side-text-to-icon-gap: var(
+    --bsf-save-btn-right-side-padding
+  );
+  /* Yt action btn height is a static 35.9896px but achieved through other styles not the height param */
+  /* FIXME Github issue #1 (manifest -> homepage_url) */
+  --bsf-yt-action-btn-height: 35.99px;
 }
 
 /****************** Basic YouTube Video ******************/
@@ -21,70 +23,122 @@ html body
 #actions #actions-inner #menu #top-level-buttons-computed
 /* SF Specific */
 .sf-quick-dl-btn {
-    height: var(--bsf-yt-action-btn-height) !important;
-    background-color: var(--yt-spec-static-overlay-button-secondary,rgba(255,255,255,.1)) !important;
-    border: none !important;
-    border-left: solid var(--bsf-save-btn-left-side-padding) transparent !important;
-    padding-left: var(--bsf-save-btn-left-side-width) !important;
-    padding-right: calc(var(--bsf-save-btn-sides-gap-width)/2) !important;
+  height: var(--bsf-yt-action-btn-height) !important;
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary,
+    rgba(255, 255, 255, 0.1)
+  ) !important;
+  border: none !important;
+  border-left: solid var(--bsf-save-btn-left-side-padding) transparent !important;
+  padding-left: var(--bsf-save-btn-left-side-width) !important;
+  padding-right: calc(var(--bsf-save-btn-sides-gap-width) / 2) !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-.sf-quick-dl-btn:hover {
-    background-color: var(--yt-spec-button-chip-background-hover,rgba(255,255,255,.2)) !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  .sf-quick-dl-btn:hover {
+  background-color: var(
+    --yt-spec-button-chip-background-hover,
+    rgba(255, 255, 255, 0.2)
+  ) !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-.sf-quick-dl-btn i {
-    transform: translateY(var(--bsf-save-btn-icon-translate-y)) !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  .sf-quick-dl-btn
+  i {
+  transform: translateY(var(--bsf-save-btn-icon-translate-y)) !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-#savefrom__yt_btn .sf-quick-dl-btn span.sf-btn-name {
-    display: none !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  #savefrom__yt_btn
+  .sf-quick-dl-btn
+  span.sf-btn-name {
+  display: none !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-#savefrom__yt_btn button {
-    height: var(--bsf-yt-action-btn-height) !important;
-    background-color: var(--yt-spec-static-overlay-button-secondary,rgba(255,255,255,.1)) !important;
-    border-width: 0 !important;
-    border-color: transparent !important;
-    border-right: solid var(--bsf-save-btn-right-side-padding) transparent !important;
-    margin-left: 0 !important;
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-    padding-left: calc(var(--bsf-save-btn-sides-gap-width)/2) !important;
-    /* Hardcoding 15 as a base value from SaveFrom.net to achieve 0 space between span and i on button */
-    padding-right: calc(15px + var(--bsf-save-btn-right-side-text-to-icon-gap)) !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  #savefrom__yt_btn
+  button {
+  height: var(--bsf-yt-action-btn-height) !important;
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary,
+    rgba(255, 255, 255, 0.1)
+  ) !important;
+  border-width: 0 !important;
+  border-color: transparent !important;
+  border-right: solid var(--bsf-save-btn-right-side-padding) transparent !important;
+  margin-left: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  padding-left: calc(var(--bsf-save-btn-sides-gap-width) / 2) !important;
+  /* Hardcoding 15 as a base value from SaveFrom.net to achieve 0 space between span and i on button */
+  padding-right: calc(
+    15px + var(--bsf-save-btn-right-side-text-to-icon-gap)
+  ) !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-#savefrom__yt_btn button:hover {
-    background-color: var(--yt-spec-button-chip-background-hover,rgba(255,255,255,.2)) !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  #savefrom__yt_btn
+  button:hover {
+  background-color: var(
+    --yt-spec-button-chip-background-hover,
+    rgba(255, 255, 255, 0.2)
+  ) !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-#savefrom__yt_btn button span {
-    color: var(--yt-spec-text-primary,rgb(241, 241, 241)) !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  #savefrom__yt_btn
+  button
+  span {
+  color: var(--yt-spec-text-primary, rgb(241, 241, 241)) !important;
 
-    /* Hardcoded in .yt-spec-button-shape-next */
-    font-size: 14px !important;
-    font-weight: 500 !important;
-    font-family: "Roboto", "Arial", sans-serif !important;
+  /* Hardcoded in .yt-spec-button-shape-next */
+  font-size: 14px !important;
+  font-weight: 500 !important;
+  font-family: "Roboto", "Arial", sans-serif !important;
 }
 
-html body
-#actions #actions-inner #menu #top-level-buttons-computed
-#savefrom__yt_btn button i {
-    transform: translateY(var(--bsf-save-btn-icon-translate-y)) !important;
-    border-color: var(--yt-spec-text-primary,rgb(241, 241, 241)) transparent transparent !important;
+html
+  body
+  #actions
+  #actions-inner
+  #menu
+  #top-level-buttons-computed
+  #savefrom__yt_btn
+  button
+  i {
+  transform: translateY(var(--bsf-save-btn-icon-translate-y)) !important;
+  border-color: var(--yt-spec-text-primary, rgb(241, 241, 241)) transparent
+    transparent !important;
 }
 
 /****************** Short YouTube Video ******************/

--- a/styles/shorts.css
+++ b/styles/shorts.css
@@ -1,0 +1,428 @@
+/* YouTube Shorts Save Button Styles */
+/* Using maximum specificity to override YouTube's styles */
+
+:root {
+  /* Shorts specific variables */
+  --bsf-shorts-btn-size: 48px;
+  --bsf-shorts-quality-btn-width: 48px;
+  --bsf-shorts-quality-btn-height: 32px;
+  --bsf-shorts-icon-size: 24px;
+  --bsf-shorts-btn-margin: 16px; /* Increased from 8px to 16px */
+}
+
+/****************** YouTube Shorts Save Button ******************/
+
+/* Shorts container styling */
+html body ytd-reel-player-overlay-renderer #like-button #savefrom__yt_btn {
+  font-family: "Roboto", "Arial", sans-serif !important;
+  font-size: 13px !important;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Main download button - circular like other Shorts buttons */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: var(--bsf-shorts-btn-size) !important;
+  height: var(--bsf-shorts-btn-size) !important;
+  min-width: var(--bsf-shorts-btn-size) !important;
+  min-height: var(--bsf-shorts-btn-size) !important;
+  border-radius: 50% !important;
+  border: none !important;
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary,
+    rgba(255, 255, 255, 0.1)
+  ) !important;
+  color: var(--yt-spec-text-primary, rgb(255, 255, 255)) !important;
+  cursor: pointer !important;
+  text-decoration: none !important;
+  transition: all 0.2s cubic-bezier(0.05, 0, 0, 1) !important;
+  position: relative !important;
+  backdrop-filter: blur(10px) !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  margin-bottom: 8px !important;
+  line-height: 1 !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+}
+
+/* Hover state */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn:hover {
+  background-color: var(
+    --yt-spec-button-chip-background-hover,
+    rgba(255, 255, 255, 0.2)
+  ) !important;
+  transform: scale(1.05) !important;
+}
+
+/* Active state */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn:active {
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary-active,
+    rgba(255, 255, 255, 0.15)
+  ) !important;
+  transform: scale(0.95) !important;
+}
+
+/* Download icon styling */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn
+  i {
+  position: static !important;
+  width: var(--bsf-shorts-icon-size) !important;
+  height: var(--bsf-shorts-icon-size) !important;
+  background-size: 20px !important;
+  background-repeat: no-repeat !important;
+  background-position: center center !important;
+  left: 0 !important;
+  top: 0 !important;
+  transform: none !important;
+  display: block !important;
+  flex-shrink: 0 !important;
+}
+
+/* Quality selector button */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button {
+  position: relative !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: var(--bsf-shorts-quality-btn-width) !important;
+  height: var(--bsf-shorts-quality-btn-height) !important;
+  min-width: var(--bsf-shorts-quality-btn-width) !important;
+  min-height: var(--bsf-shorts-quality-btn-height) !important;
+  padding: 0 8px !important;
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary,
+    rgba(255, 255, 255, 0.1)
+  ) !important;
+  border: 1px solid var(--yt-spec-10-percent-layer, rgba(255, 255, 255, 0.2)) !important;
+  border-radius: 16px !important;
+  cursor: pointer !important;
+  color: var(--yt-spec-text-primary, rgb(255, 255, 255)) !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  font-family: "Roboto", "Arial", sans-serif !important;
+  transition: all 0.2s cubic-bezier(0.05, 0, 0, 1) !important;
+  backdrop-filter: blur(10px) !important;
+  margin: 0 !important;
+  margin-bottom: var(--bsf-shorts-btn-margin) !important;
+  line-height: 1 !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+}
+
+/* Quality button hover state */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button:hover {
+  background-color: var(
+    --yt-spec-button-chip-background-hover,
+    rgba(255, 255, 255, 0.2)
+  ) !important;
+  border-color: var(
+    --yt-spec-20-percent-layer,
+    rgba(255, 255, 255, 0.3)
+  ) !important;
+}
+
+/* Quality button active state */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button:active {
+  background-color: var(
+    --yt-spec-static-overlay-button-secondary-active,
+    rgba(255, 255, 255, 0.15)
+  ) !important;
+  transform: scale(0.98) !important;
+}
+
+/* Quality text styling */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button
+  span {
+  margin: 0 !important;
+  vertical-align: middle !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  color: var(--yt-spec-text-primary, rgb(255, 255, 255)) !important;
+  line-height: 1 !important;
+  flex-shrink: 0 !important;
+}
+
+/* Dropdown arrow styling */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button
+  i {
+  position: absolute !important;
+  right: 4px !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  border-width: 4px !important;
+  border-style: solid !important;
+  border-color: var(--yt-spec-text-primary, rgba(255, 255, 255, 0.8))
+    transparent transparent !important;
+  width: 0 !important;
+  height: 0 !important;
+  background: none !important;
+  background-image: none !important;
+}
+
+/* Touch feedback effect for download button */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn::before {
+  content: "" !important;
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  width: 0 !important;
+  height: 0 !important;
+  border-radius: 50% !important;
+  background-color: rgba(255, 255, 255, 0.3) !important;
+  transform: translate(-50%, -50%) !important;
+  transition: width 0.3s cubic-bezier(0.05, 0, 0, 1),
+    height 0.3s cubic-bezier(0.05, 0, 0, 1) !important;
+  z-index: -1 !important;
+  pointer-events: none !important;
+}
+
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn:active::before {
+  width: 60px !important;
+  height: 60px !important;
+}
+
+/* Touch feedback effect for quality button */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button::before {
+  content: "" !important;
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  width: 0 !important;
+  height: 0 !important;
+  border-radius: inherit !important;
+  background-color: rgba(255, 255, 255, 0.2) !important;
+  transform: translate(-50%, -50%) !important;
+  transition: width 0.2s ease, height 0.2s ease !important;
+  z-index: -1 !important;
+  pointer-events: none !important;
+}
+
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button:active::before {
+  width: calc(100% + 8px) !important;
+  height: calc(100% + 8px) !important;
+}
+
+/* Hide button name text for Shorts */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn
+  span.sf-btn-name {
+  display: none !important;
+}
+
+/* Focus states for accessibility */
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  .sf-quick-dl-btn:focus-visible {
+  outline: 2px solid var(--yt-spec-text-primary, rgb(255, 255, 255)) !important;
+  outline-offset: 2px !important;
+}
+
+html
+  body
+  ytd-reel-player-overlay-renderer
+  #like-button
+  #savefrom__yt_btn
+  button:focus-visible {
+  outline: 2px solid var(--yt-spec-text-primary, rgb(255, 255, 255)) !important;
+  outline-offset: 2px !important;
+}
+
+/****************** Mobile Responsive ******************/
+@media (max-width: 768px) {
+  :root {
+    --bsf-shorts-btn-size: 44px;
+    --bsf-shorts-quality-btn-width: 44px;
+    --bsf-shorts-quality-btn-height: 28px;
+    --bsf-shorts-icon-size: 20px;
+    --bsf-shorts-btn-margin: 12px; /* Increased from 6px to 12px */
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button
+    span {
+    font-size: 11px !important;
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button
+    i {
+    border-width: 3px !important;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --bsf-shorts-btn-size: 40px;
+    --bsf-shorts-quality-btn-width: 40px;
+    --bsf-shorts-quality-btn-height: 24px;
+    --bsf-shorts-icon-size: 18px;
+    --bsf-shorts-btn-margin: 10px; /* Increased from 4px to 10px */
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button {
+    padding: 0 6px !important;
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button
+    span {
+    font-size: 10px !important;
+  }
+}
+
+/****************** Dark/Light Theme Support ******************/
+@media (prefers-color-scheme: light) {
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    .sf-quick-dl-btn {
+    background-color: var(
+      --yt-spec-static-overlay-button-secondary,
+      rgba(0, 0, 0, 0.05)
+    ) !important;
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    .sf-quick-dl-btn:hover {
+    background-color: var(
+      --yt-spec-button-chip-background-hover,
+      rgba(0, 0, 0, 0.1)
+    ) !important;
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button {
+    background-color: var(
+      --yt-spec-static-overlay-button-secondary,
+      rgba(0, 0, 0, 0.05)
+    ) !important;
+    border-color: var(
+      --yt-spec-10-percent-layer,
+      rgba(0, 0, 0, 0.1)
+    ) !important;
+  }
+
+  html
+    body
+    ytd-reel-player-overlay-renderer
+    #like-button
+    #savefrom__yt_btn
+    button:hover {
+    background-color: var(
+      --yt-spec-button-chip-background-hover,
+      rgba(0, 0, 0, 0.1)
+    ) !important;
+    border-color: var(
+      --yt-spec-20-percent-layer,
+      rgba(0, 0, 0, 0.2)
+    ) !important;
+  }
+}


### PR DESCRIPTION
Known Issues:
Due to YouTube's SPA architecture:
- When a user navigates to a Shorts page from the homepage or from a /watch page, the SaveFrom button **may not appear correctly until the page is manually reloaded.**
- This is because the extension doesn't inject CSS dynamically based on client-side routing.
- If the user lands directly on a /shorts/... URL, everything works as expected.
YouTube is a Single Page Application (SPA). It doesn't fully reload the page on navigation. Because this extension is CSS-only, styles are injected only once when the page initially loads.
To fix this completely would require JavaScript logic to detect route changes — which is not possible in this CSS-only extension.
What Was Changed:

-     Created a separate CSS file specifically for styling SaveFrom buttons on YouTube Shorts pages.
-     Added new layout:
          The Save button now appears above the quality selection (i) icon (stacked vertically).
          Styled as round buttons for better consistency with Shorts UI.
-     Ensured compatibility with both dark and light themes using CSS variables.
Before:
<img width="564" height="535" alt="before" src="https://github.com/user-attachments/assets/34da1ae1-34ba-4444-933b-7914c133e2f0" />
After:
<img width="606" height="843" alt="after" src="https://github.com/user-attachments/assets/ec83f5d4-d166-43fe-b764-321c545dc632" />